### PR TITLE
Add option to disable notifications

### DIFF
--- a/yubiswitch/AppDelegate.h
+++ b/yubiswitch/AppDelegate.h
@@ -42,6 +42,7 @@
 
 -(IBAction)toggleSwitchOffDelay:(id)sender;
 -(IBAction)toggleLockWhenUnplugged:(id)sender;
+-(IBAction)toggleDisplayNotications:(id)sender;
 -(IBAction)toggle:(id)sender;
 -(IBAction)quit:(id)sender;
 -(IBAction)about:(id)sender;

--- a/yubiswitch/AppDelegate.m
+++ b/yubiswitch/AppDelegate.m
@@ -118,6 +118,9 @@
 }
 
 -(void)notify:(NSString *)msg {
+    BOOL displayNotifications = [[NSUserDefaults standardUserDefaults]
+                                 boolForKey:@"displayNotifications"];
+    if (!displayNotifications) return;
     usernotification.title = msg;
     [[NSUserNotificationCenter defaultUserNotificationCenter]
      deliverNotification:usernotification];
@@ -193,6 +196,10 @@
 }
 
 -(IBAction)toggleLockWhenUnplugged:(id)sender {
+    [controller save:self];
+}
+
+- (IBAction)toggleDisplayNotications:(id)sender {
     [controller save:self];
 }
 

--- a/yubiswitch/Base.lproj/MainMenu.xib
+++ b/yubiswitch/Base.lproj/MainMenu.xib
@@ -54,6 +54,13 @@
                         </binding>
                     </connections>
                 </menuItem>
+                <menuItem title="Display notifications" id="zaa-1a-4ru">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="toggleDisplayNotications:" target="494" id="X9f-ho-1Em"/>
+                        <binding destination="BET-T9-5EC" name="value" keyPath="values.displayNotifications" id="42y-ke-7fE"/>
+                    </connections>
+                </menuItem>
                 <menuItem title="Preferences..." id="ZbY-4K-DDd">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>

--- a/yubiswitch/DefaultPreferences.plist
+++ b/yubiswitch/DefaultPreferences.plist
@@ -28,5 +28,7 @@
 	</dict>
 	<key>startAtLogin</key>
 	<false/>
+	<key>displayNotifications</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This is an implementation of Issue #11 to provide an option to disable notifications. It defaults to displaying the notifications, so there is no change in behavior for existing users.
