### PR TITLE
Expose yubikey status to apple script

### DIFF
--- a/YubiSwitch.sdef
+++ b/YubiSwitch.sdef
@@ -9,5 +9,9 @@
         <command name="KeyOff" code="yubicOff" description="Disables yubikey">
             <cocoa class="YubiKeyScript"/>
         </command>
+        <class name="yubikey" code="yubi" description="Yubikey">
+            <cocoa class="NSApplication"/>
+            <property name="status" code="stat" type="boolean" description="Is the yubikey enabled?"/>
+        </class>
     </suite>
 </dictionary>

--- a/yubiswitch/AppDelegate.h
+++ b/yubiswitch/AppDelegate.h
@@ -56,5 +56,7 @@
 -(void)reDisableYK;
 -(NSTimer*)createTimer:(NSInteger)interval;
 -(void)lockComputer;
+-(bool)application:(NSApplication *)sender delegateHandlesKey:(NSString *)key;
+-(bool)status;
 
 @end

--- a/yubiswitch/AppDelegate.m
+++ b/yubiswitch/AppDelegate.m
@@ -207,6 +207,14 @@
     }
 }
 
+-(bool)application:(NSApplication *)sender delegateHandlesKey:(NSString *)key {
+    return [key isEqualToString:@"status"]; 
+}
+
+- (bool)status {
+    return isEnabled;
+}
+
 - (IBAction)toggle:(id)sender {
     if (isEnabled == TRUE) {
         [self enableYubiKey:FALSE];


### PR DESCRIPTION
Fixes #74 

Exposes the yubikey status to AppleScript which allows you to do:

`osascript -e "tell application \"yubiswitch\" to get status"`

![screen shot 2018-03-08 at 4 38 58 pm](https://user-images.githubusercontent.com/419708/37178716-543e2a36-22f1-11e8-9413-ba365234cb75.png)

