### PR TITLE
Fix initial setup problem: Yubikey vs YubiKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ osascript -e 'tell application "yubiswitch" to KeyOff'
 To find the product and vendor ids, do the following in the terminal:
 
 ```
-$ ioreg -p IOUSB -l -w 0 -x | grep Yubikey -A10 | grep 'idProduct\|idVendor'
+$ ioreg -p IOUSB -l -w 0 -x | grep -i Yubikey -A10 | grep 'idProduct\|idVendor'
           "idProduct" = 0x116
           "idVendor" = 0x1050
 ```
@@ -65,7 +65,7 @@ If you have brew installed and [prefer lsusb-style output](http://stackoverflow.
 ```
 $ brew update && brew tap jlhonora/lsusb && brew install lsusb
 
-$ lsusb | grep Yubikey
+$ lsusb | grep -i Yubikey
 Bus 020 Device 022: ID 1050:0116 1050 Yubikey NEO OTP+U2F+CCID
 ```
 


### PR DESCRIPTION
I just got a new YubiKey Nano 5C, and the setup process wasn't working for me because I couldn't find the Product ID and Vendor ID. I traced it to a case sensitivity issue with `grep`.

Here is the YubiKey output of `lsusb`:

```
Bus 020 Device 001: ID 1050:0407 1050 YubiKey OTP+FIDO+CCID
```

Note the upper case "K" in YubiKey.

Similar with `ioreg -p IOUSB -l -w 0 -x`

```
"USB Product Name" = "YubiKey OTP+FIDO+CCID"
```

Looking at the [Yubico website](https://www.yubico.com/products/yubikey-hardware/), the product name is actually YubiKey with a capital K.

I've made the `grep` command case-insensitive in the setup instructions so that both `Yubikey` and `YubiKey` are found. `-i` ignores case in both GNU grep and grep included in macOS.