### PR TITLE
Rename Yubiswitch -> YubiSwitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This status bar app allows you to avoid sending those accidental OTP passwords b
 Download the latest version in DMG format from [github release page here](https://github.com/pallotron/yubiswitch/releases/).
 
 # Running
-This application needs to run with escalated privileges in order to exclusively grab the USB HID interface that drives the NANO/NEO-n Yubikey. Running the main app as root is a p.i.t.a. so Yubiswitch installs an helper daemon with root privileges which contains the logic to grab the USB HID interface, the main application talks to this daemon via XPC calls. When you start Yubiswitch for the first time it will ask for your user's password, this is expected to install the helper before mentioned.
+This application needs to run with escalated privileges in order to exclusively grab the USB HID interface that drives the NANO/NEO-n Yubikey. Running the main app as root is a p.i.t.a. so YubiSwitch installs an helper daemon with root privileges which contains the logic to grab the USB HID interface, the main application talks to this daemon via XPC calls. When you start YubiSwitch for the first time it will ask for your user's password, this is expected to install the helper before mentioned.
 
 If you use your Yubikey as part of [multi-factor authentication for Mac](https://www.yubico.com/wp-content/uploads/2015/04/YubiKey-OSX-Login.pdf) then you might want to make sure that the option "Enable yubiky when sytem locks/sleeps" is enabled.
 

--- a/yubiswitch/AboutWindowController.xib
+++ b/yubiswitch/AboutWindowController.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application"/>
-        <window title="About Yubiswitch" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="iua-nl-brR">
+        <window title="About YubiSwitch" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="iua-nl-brR">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="478" y="350" width="516" height="163"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>

--- a/yubiswitch/PreferencesController.xib
+++ b/yubiswitch/PreferencesController.xib
@@ -155,7 +155,7 @@ Gw
                     </customView>
                     <button toolTip="If set yubiswtich will start at login time" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="afm-iG-Ff1">
                         <rect key="frame" x="311" y="64" width="176" height="18"/>
-                        <buttonCell key="cell" type="check" title="Start Yubiswitch at login" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Adi-wS-wdB">
+                        <buttonCell key="cell" type="check" title="Start YubiSwitch at login" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Adi-wS-wdB">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>


### PR DESCRIPTION
There was a sway between `Yubiswitch` and `YubiSwitch`.
I thought `YubiSwitch` was correct, so I fixed it.