### PR TITLE
Requirements for notarizing

### DIFF
--- a/com.pallotron.yubiswitch.helper.entitlements
+++ b/com.pallotron.yubiswitch.helper.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/dmg/createdmg.sh
+++ b/dmg/createdmg.sh
@@ -25,10 +25,10 @@ tmpdir=$(mktemp -d -t yubiswitch)
 echo "Tempdir: $tmpdir"
 
 echo "Copying skeleton contents to $tmpdir"
-cp -R skeleton $tmpdir
+cp -R skeleton/ $tmpdir
 
 echo "Copying $SRC_BINARY to $tmpdir"
-rsync -a $SRC_BINARY/ $tmpdir
+rsync -a $SRC_BINARY $tmpdir/
 
 echo "Creating new disk image at $OUTPUT"
 hdiutil create -volName yubiswitch -srcfolder $tmpdir $OUTPUT

--- a/yubiswitch.helper/yubiswitch-helper-Info.plist
+++ b/yubiswitch.helper/yubiswitch-helper-Info.plist
@@ -12,7 +12,7 @@
 	<string>2.0</string>
 	<key>SMAuthorizedClients</key>
 	<array>
-		<string>identifier "com.pallotron.yubiswitch" and anchor apple generic and certificate leaf[subject.CN] = "Apple Development: David Rothera (G54X79V8CR)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+		<string>anchor apple generic and identifier "com.pallotron.yubiswitch" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YX97W249KL)</string>
 	</array>
 </dict>
 </plist>

--- a/yubiswitch.xcodeproj/project.pbxproj
+++ b/yubiswitch.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		59EF40691B13D19A0000BB5F /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		59EF406B1B13D1A60000BB5F /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
 		59EF407C1B13E1490000BB5F /* yubiswitch-helper-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "yubiswitch-helper-Info.plist"; sourceTree = "<group>"; };
+		63AE427928E50E4E0058E8B4 /* yubiswitch.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = yubiswitch.entitlements; sourceTree = "<group>"; };
+		63AE427B28E50E5F0058E8B4 /* com.pallotron.yubiswitch.helper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = com.pallotron.yubiswitch.helper.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -222,6 +224,7 @@
 		59E5CF0217EC2A9000898135 = {
 			isa = PBXGroup;
 			children = (
+				63AE427B28E50E5F0058E8B4 /* com.pallotron.yubiswitch.helper.entitlements */,
 				59013C7F17F56F0F00005A7E /* ShortcutRecorder.xcodeproj */,
 				59EC128917ECFAFD00B3C3A6 /* README.md */,
 				594DCCE617EF99D400D9C2E2 /* LICENSE */,
@@ -270,6 +273,7 @@
 		59E5CF1417EC2A9000898135 /* yubiswitch */ = {
 			isa = PBXGroup;
 			children = (
+				63AE427928E50E4E0058E8B4 /* yubiswitch.entitlements */,
 				593B4E0617F09362003195DE /* AboutWindowController.h */,
 				593B4E0717F09362003195DE /* AboutWindowController.m */,
 				593B4E0817F09362003195DE /* AboutWindowController.xib */,
@@ -367,10 +371,11 @@
 					593AE45C1B1371B700FCA848 = {
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = YX97W249KL;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					59E5CF0A17EC2A9000898135 = {
 						DevelopmentTeam = YX97W249KL;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -538,10 +543,14 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_ENTITLEMENTS = com.pallotron.yubiswitch.helper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = YX97W249KL;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = YX97W249KL;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -572,10 +581,14 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_ENTITLEMENTS = com.pallotron.yubiswitch.helper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = YX97W249KL;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = YX97W249KL;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
@@ -671,9 +684,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = yubiswitch/yubiswitch.entitlements;
 				CODE_SIGN_IDENTITY = "Mac Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = YX97W249KL;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = YX97W249KL;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "yubiswitch/yubiswitch-Prefix.pch";
 				INFOPLIST_FILE = "yubiswitch/yubiswitch-Info.plist";
@@ -681,6 +699,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -689,9 +708,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = yubiswitch/yubiswitch.entitlements;
 				CODE_SIGN_IDENTITY = "Mac Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = YX97W249KL;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = YX97W249KL;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "yubiswitch/yubiswitch-Prefix.pch";
 				INFOPLIST_FILE = "yubiswitch/yubiswitch-Info.plist";
@@ -699,6 +723,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/yubiswitch/yubiswitch-Info.plist
+++ b/yubiswitch/yubiswitch-Info.plist
@@ -29,7 +29,7 @@
 	<key>NSAppleScriptEnabled</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright (C) 2013-present  Angelo &quot;pallotron&quot; Failla &lt;pallotron@freaknet.org&gt; -- GNUGPL v3</string>
+	<string>Copyright (C) 2013-present  Angelo "pallotron" Failla &lt;pallotron@freaknet.org&gt; -- GNUGPL v3</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
@@ -39,7 +39,7 @@
 	<key>SMPrivilegedExecutables</key>
 	<dict>
 		<key>com.pallotron.yubiswitch.helper</key>
-		<string>identifier &quot;com.pallotron.yubiswitch.helper&quot; and anchor apple generic and certificate leaf[subject.CN] = &quot;Apple Development: David Rothera (G54X79V8CR)&quot; and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+		<string>anchor apple generic and identifier "com.pallotron.yubiswitch.helper" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YX97W249KL)</string>
 	</dict>
 </dict>
 </plist>

--- a/yubiswitch/yubiswitch.entitlements
+++ b/yubiswitch/yubiswitch.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>


### PR DESCRIPTION
As of a few years ago Apple now requires apps to be "notarized" so that they are screened for malware and other issues. This is presented to the user as warnings/errors when opening dmg images as well as running the apps themselves.

One requirement for us to be able to notarize the app is enable the "hardened runtime" which limits capabilities of the app but functionality remains working ok.

This PR enables those changes so we can then publish new notarized releases.

Notes for *how* to notarize are from [here](https://wiki.lazarus.freepascal.org/Notarization_for_macOS_10.14.5%2B)