### PR TITLE
Bump the helper version number to ensure it is updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,57 @@
-# Xcode
+# Created by https://www.toptal.com/developers/gitignore/api/macos,xcode
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,xcode
+
+### macOS ###
+# General
 .DS_Store
-*/build/*
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-xcuserdata
-profile
-*.moved-aside
-DerivedData
-.idea/
-*.hmap
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Xcode ###
+## User settings
+xcuserdata/
+
+## Xcode 8 and earlier
+*.xcscmblueprint
 *.xccheckout
 
-#CocoaPods
-Pods
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/*
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+DerivedData
 
+## DMG
 *.dmg
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,xcode

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Preference window:
 - The app's default settings support the Nano. If you have a different model, go into the app's `Preferences` by clicking on the menu icon, then set the the `Product ID` to `0x0114` (or whatever your ProductID is) see: [How to find ProductID and VendorID](#how-to-find-productid-and-vendorid).
 - If your YubiKey is not working, you might want to confirm the `Product ID` and `Vendor ID` follow the how to find your ProductID and VendorID steps below
 - This app only works with recent version of OSX because it relies on the Notification Centre. OSX 10.8.x and above would do it. Sorry about that.
+- If your `Product ID` and `Vendor ID` are correct but the app is not working then please follow the uninstall instructions and update to the latest release version.
 
 
 # TODO and future plans
@@ -132,14 +133,6 @@ When you want to create a release:
 `yubiswitch` uses ShortcutRecoder to implement global hot key and shortcuts recording in the the preference window.
 
 - ShortcutRecorder is at : [https://github.com/Kentzo/ShortcutRecorder](https://github.com/Kentzo/ShortcutRecorder)
-- I'll need to add it to your `yubiswitch` clone using git submodule using
-- command:
-
-```
-git submodule add git://github.com/Kentzo/ShortcutRecorder.git
-```
-
-See [this helpful page](https://github.com/Kentzo/ShortcutRecorder) for instructions on how to set up your Xcode environment should you have any problem.
 
 # How to uninstall
 

--- a/yubiswitch.helper/yubiswitch-helper-Info.plist
+++ b/yubiswitch.helper/yubiswitch-helper-Info.plist
@@ -9,10 +9,10 @@
 	<key>CFBundleName</key>
 	<string>yubiswitch.helper</string>
 	<key>CFBundleVersion</key>
-	<string>2.0</string>
+	<string>3</string>
 	<key>SMAuthorizedClients</key>
 	<array>
-		<string>anchor apple generic and identifier "com.pallotron.yubiswitch" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YX97W249KL)</string>
+		<string>anchor apple generic and identifier &quot;com.pallotron.yubiswitch&quot; and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YX97W249KL)</string>
 	</array>
 </dict>
 </plist>

--- a/yubiswitch/yubiswitch-Info.plist
+++ b/yubiswitch/yubiswitch-Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15</string>
+	<string>0.16</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.15</string>
+	<string>0.16</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Due to the fact that we now use a different certificate for communicating/signing the binaries if you have an old version installed it won't work.

It might be worth adding a "can I communicate with the helper" rather than just relying on the version from the plist but until then this will suffice.

Fixes #118 