### PR TITLE
docs: fix final uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Remove files from filesystem:
 
 ```
 # sudo rm /Library/PrivilegedHelperTools/com.pallotron.yubiswitch.helper
-# sudo rm /Applications/yubiswitch.app/
+# sudo rm -r /Applications/yubiswitch.app/
 ```
 
 Maybe one day I will provide a script to do this.


### PR DESCRIPTION
The final rm command, `sudo rm -r /Applications/yubiswitch.app/` refers to a directory and this needs the `-r` switch to execute successfully.