### PR TITLE
Invalidate lingering switch-off timer

### DIFF
--- a/yubiswitch/AppDelegate.m
+++ b/yubiswitch/AppDelegate.m
@@ -181,6 +181,8 @@
         res = [yk disable];
     }
     if (res == TRUE) {
+        [reDisableTimer invalidate];
+        reDisableTimer = nil;
         if (enable == TRUE) {
             [statusItem setToolTip:(@"YubiKey enabled")];
             [statusItem setImage:[NSImage imageNamed:@"YubikeyEnabled"]];
@@ -257,6 +259,7 @@
     [yk enable];
     [self notify:@"YubiKey enabled"];
     [reDisableTimer invalidate];
+    reDisableTimer = nil;
     [[NSApplication sharedApplication] terminate:self];
 }
 


### PR DESCRIPTION
The previous switch-off timer is not invalidated when enabling the YubiKey, this means that a previous enable request's timer can trigger and disable the YubiKey earlier than it should.