### PR TITLE
Add yubiswitch uninstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,19 @@ When you want to create a release:
 
 # How to uninstall
 
-Uninstallation process is pretty manual. Execute this as root:
+You can uninstall yubiswitch using the provided script or manually following the steps below.
+
+## Automated uninstall
+
+To automatically uninstall yubiswitch, run this command as root:
+
+```
+$ curl -fsSL https://raw.githubusercontent.com/pallotron/yubiswitch/master/scripts/uninstall.sh | sudo zsh
+```
+
+## Manual uninstall
+
+If you prefer to manually uninstall, execute these steps as root:
 
 Kill all processes:
 
@@ -166,8 +178,6 @@ Remove files from filesystem:
 # sudo rm /Library/PrivilegedHelperTools/com.pallotron.yubiswitch.helper
 # sudo rm -r /Applications/yubiswitch.app/
 ```
-
-Maybe one day I will provide a script to do this.
 
 # Credits
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,68 @@
+#!/bin/zsh
+
+# Uninstall script for yubiswitch
+
+# Check for root privileges
+if [ "$EUID" -ne 0 ]; then
+    echo "This script must be run as root."
+    echo "Please run again with sudo: sudo $0"
+    exit 1
+fi
+
+echo "Uninstalling yubiswitch..."
+
+echo "Killing yubiswitch and helper processes..."
+pkill -f yubiswitch.app > /dev/null 2>&1
+pkill -f com.pallotron.yubiswitch.helper > /dev/null 2>&1
+
+
+# Stop and remove launchctl service
+echo "Stopping and removing launchctl service..."
+launchctl stop com.pallotron.yubiswitch.helper > /dev/null 2>&1
+launchctl remove com.pallotron.yubiswitch.helper > /dev/null 2>&1
+
+# Verify service is gone with retries since it seems to take a little while to
+# be removed.
+echo "Verifying service removal..."
+attempts=0
+max_attempts=18  # Try for up to 60 seconds (12 * 5 seconds)
+
+while [ $attempts -lt $max_attempts ]; do
+    if launchctl list | grep -i yubi > /dev/null 2>&1; then
+        attempts=$((attempts + 1))
+        if [ $attempts -lt $max_attempts ]; then
+            echo "Service still found, waiting 5 seconds for it to unload... (Attempt $attempts/$max_attempts)"
+            sleep 5
+        else
+            echo "Warning: Yubiswitch service still found in 'launchctl list' after 1 minute."
+            echo "Please manually stop and remove it with:"
+            echo
+            echo "    sudo launchctl stop com.pallotron.yubiswitch.helper"
+            echo "    sudo launchctl remove com.pallotron.yubiswitch.helper"
+            echo
+            echo "and then run this script again."
+            exit 1
+        fi
+    else
+        echo "yubiswitch service successfully removed."
+        break
+    fi
+done
+
+# Remove files
+echo "Removing yubiswitch files..."
+rm -f /Library/PrivilegedHelperTools/com.pallotron.yubiswitch.helper
+rm -rf /Applications/yubiswitch.app/
+
+# Check if files were removed successfully
+if [ -f "/Library/PrivilegedHelperTools/com.pallotron.yubiswitch.helper" ] || [ -d "/Applications/yubiswitch.app/" ]; then
+    echo "Warning: Failed to remove some yubiswitch files. Please try removing them manually with:
+
+    sudo rm -f /Library/PrivilegedHelperTools/com.pallotron.yubiswitch.helper
+    sudo rm -rf /Applications/yubiswitch.app/"
+    exit 1
+else
+    echo "yubiswitch files successfully removed."
+fi
+
+echo "Uninstallation complete."


### PR DESCRIPTION
Had to do the uninstall/reinstall of yubiswitch today, took a few minutes to write an uninstall script.

# Testing
```
## Installed
ls -l /Applications | grep -i yubiswitch
drwxr-xr-x@ 3 squizzi  admin   96 Oct 30  2024 yubiswitch.app

ls -l /Library/PrivilegedHelperTools/ | grep -i yubiswitch
-r-xr--r--@ 1 root  wheel   137152 May  7 10:08 com.pallotron.yubiswitch.helper

launchctl list | grep -i yubi
680	0	application.com.pallotron.yubiswitch.23855493.23855498

## Run script
sudo ./scripts/uninstall.sh
Uninstalling yubiswitch...
Killing yubiswitch and helper processes...
Stopping and removing launchctl service...
Verifying service removal...
Service still found, waiting 5 seconds for it to unload... (Attempt 1/12)
yubiswitch service successfully removed.
Removing yubiswitch files...
yubiswitch files successfully removed.
Uninstallation complete.

## Uninstalled
ls -l /Applications | grep -i yubiswitch
<none>

launchctl list | grep -i yubi
<none>

ls -l /Library/PrivilegedHelperTools | grep -i yubiswitch
<none>
```