### PR TITLE
Switch all keys with configurable override

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -1,0 +1,30 @@
+name: Xcode - Build and Analyze
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    name: Build and analyse default scheme using xcodebuild command
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set Default Scheme
+        run: |
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo $default | cat >default
+          echo Using default scheme: $default
+      - name: Build
+        env:
+          scheme: ${{ 'default' }}
+        run: |
+          if [ $scheme = default ]; then scheme=$(cat default); fi
+          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          xcodebuild clean build analyze -scheme "$scheme" -"$filetype_parameter" "$file_to_build" | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -27,4 +27,4 @@ jobs:
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild clean build analyze -scheme "$scheme" -"$filetype_parameter" "$file_to_build" | xcpretty && exit ${PIPESTATUS[0]}
+          xcodebuild clean build analyze -scheme "$scheme" -"$filetype_parameter" "$file_to_build" CODE_SIGNING_ALLOWED=NO | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -27,4 +27,4 @@ jobs:
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild clean build analyze -scheme "$scheme" -"$filetype_parameter" "$file_to_build" CODE_SIGNING_ALLOWED=NO | xcpretty && exit ${PIPESTATUS[0]}
+          xcodebuild clean build analyze -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ShortcutRecorder"]
 	path = ShortcutRecorder
-	url = git@github.com:Kentzo/ShortcutRecorder.git
+	url = https://github.com/Kentzo/ShortcutRecorder.git

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Preference window:
 
 # Known Issues
 
-- The app's default settings support the Nano. If you have a different model, go into the app's `Preferences` by clicking on the menu icon, then set the the `Product ID` to `0x0114` (or whatever your ProductID is) see: [How to find ProductID and VendorID](#how-to-find-productid-and-vendorid).
+- By default the app controls **any** Yubico device, regardless of its Product ID: leave the `Product ID` field in `Preferences` blank. To restrict control to specific models, enter a comma-separated list of hex Product IDs (e.g. `0x0010,0x0407`) — only those will be controlled. See: [How to find ProductID and VendorID](#how-to-find-productid-and-vendorid).
 - If your YubiKey is not working, you might want to confirm the `Product ID` and `Vendor ID` follow the how to find your ProductID and VendorID steps below
 - This app only works with recent version of OSX because it relies on the Notification Centre. OSX 10.8.x and above would do it. Sorry about that.
 - If your `Product ID` and `Vendor ID` are correct but the app is not working then please follow the uninstall instructions and update to the latest release version.
@@ -118,7 +118,7 @@ Preference window:
 - [x] Feature: lock computer when yubikey is removed (use IOServiceAddMatchingNotification in IOKit?)
 - [x] Support more yubikeys nano on multiple USB slots
 - [x] Better support for plug and unplug events (fixed with HID interface, dmg not published yet)
-- [ ] Feature: support all YubiCo devices without any configuration needed
+- [x] Feature: support all YubiCo devices without any configuration needed
 
 # How to create DMG for distribution
 

--- a/yubiswitch.helper/main.c
+++ b/yubiswitch.helper/main.c
@@ -32,11 +32,10 @@
 
 
 IOHIDManagerRef hidManager;
-// Set of currently seized IOHIDDeviceRefs. Using a set (instead of a single
-// global) lets us seize and, crucially, release every matching key when several
-// Yubico devices are plugged in at once. kCFTypeSetCallBacks retains on add and
-// releases on remove, and dedups identical device refs.
-CFMutableSetRef seizedDevices;
+// Devices currently locked. A set (not a single ref) lets us release every
+// matching key when several are plugged in at once; kCFTypeSetCallBacks
+// retains/releases refs and dedups.
+CFMutableSetRef lockedDevices;
 
 static void match_set(CFMutableDictionaryRef dict, CFStringRef key, int value) {
     CFNumberRef number = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &value);
@@ -48,23 +47,22 @@ static void close_device_apply(const void *value, void *context) {
     IOHIDDeviceClose((IOHIDDeviceRef)value, kIOHIDOptionsTypeSeizeDevice);
 }
 
-// Release every seized device and empty the set.
-static void close_all_seized(void) {
-    if (seizedDevices != NULL) {
-        CFSetApplyFunction(seizedDevices, close_device_apply, NULL);
-        CFSetRemoveAllValues(seizedDevices);
+// Release every locked device and empty the set.
+static void close_all_locked(void) {
+    if (lockedDevices != NULL) {
+        CFSetApplyFunction(lockedDevices, close_device_apply, NULL);
+        CFSetRemoveAllValues(lockedDevices);
     }
 }
 
 static void handle_removal_callback(void *context, IOReturn result,
                                     void *sender, IOHIDDeviceRef device) {
-    // Only release the device that was actually unplugged. Leave the manager and
-    // any other seized devices in place so remaining keys stay seized and a
-    // re-plug of the same product still matches.
-    if (seizedDevices != NULL && CFSetContainsValue(seizedDevices, device)) {
+    // Release only the unplugged device; leave the manager and other locked
+    // devices in place so remaining keys stay locked and re-plugs still match.
+    if (lockedDevices != NULL && CFSetContainsValue(lockedDevices, device)) {
         syslog(LOG_NOTICE, "device unplugged");
         IOHIDDeviceClose(device, kIOHIDOptionsTypeSeizeDevice);
-        CFSetRemoveValue(seizedDevices, device);
+        CFSetRemoveValue(lockedDevices, device);
     }
 
     // lock screen
@@ -79,11 +77,11 @@ static void match_callback(void *context, IOReturn result, void *sender,
     IOReturn r = IOHIDDeviceOpen(device, kIOHIDOptionsTypeSeizeDevice);
     if (r == kIOReturnSuccess) {
         syslog(LOG_NOTICE, "Open'ed HID device");
-        if (seizedDevices == NULL) {
-            seizedDevices = CFSetCreateMutable(kCFAllocatorDefault, 0,
+        if (lockedDevices == NULL) {
+            lockedDevices = CFSetCreateMutable(kCFAllocatorDefault, 0,
                                                &kCFTypeSetCallBacks);
         }
-        CFSetAddValue(seizedDevices, device);
+        CFSetAddValue(lockedDevices, device);
     } else {
         syslog(LOG_ALERT, "Failed to open HID device, error: %d", r);
     }
@@ -113,11 +111,8 @@ static CFDictionaryRef matching_dictionary_create(int vendorID, int productID,
     return match;
 }
 
-// Build the array of matching dictionaries handed to
-// IOHIDManagerSetDeviceMatchingMultiple (OR semantics across the array).
-// count == 0 means "no specific product IDs": match every product for the
-// vendor (a single vendor-only dictionary). Otherwise one dictionary per
-// product ID.
+// Matching dictionaries for IOHIDManagerSetDeviceMatchingMultiple (OR semantics).
+// count == 0 matches every product for the vendor; otherwise one dict per product.
 static CFArrayRef matching_dictionaries_create(int vendorID, const int *productIDs,
                                                size_t count, int usagePage,
                                                int usage) {
@@ -150,30 +145,22 @@ static void __XPC_Peer_Event_Handler(xpc_connection_t connection,
         uint64_t idVendor = xpc_dictionary_get_int64(event, "idVendor");
         uint64_t action = xpc_dictionary_get_int64(event, "request");
 
-        // Collect the requested product IDs. Prefer the "idProducts" array; fall
-        // back to the legacy single "idProduct" key so an older GUI still works.
-        // An empty list means "match all products for the vendor".
+        // Product IDs to control; an empty list matches all products for the vendor.
         int products[256];
         size_t productCount = 0;
         xpc_object_t idProducts = xpc_dictionary_get_value(event, "idProducts");
         if (idProducts != NULL && xpc_get_type(idProducts) == XPC_TYPE_ARRAY) {
             size_t n = xpc_array_get_count(idProducts);
             for (size_t i = 0; i < n && productCount < 256; i++) {
-                products[productCount++] =
-                    (int)xpc_array_get_int64(idProducts, i);
-            }
-        } else {
-            uint64_t idProduct = xpc_dictionary_get_int64(event, "idProduct");
-            if (idProduct != 0) {
-                products[productCount++] = (int)idProduct;
+                products[productCount++] = (int)xpc_array_get_int64(idProducts, i);
             }
         }
         syslog(LOG_NOTICE,
                "Received message. idVendor: %llu, product count: %zu, action: %llu",
                idVendor, productCount, action);
         if (action == 1) {
-            // enable: release every seized device and tear down the manager
-            close_all_seized();
+            // enable: release every locked device and tear down the manager
+            close_all_locked();
             if (hidManager != NULL) {
                 IOHIDManagerClose(hidManager, kIOHIDOptionsTypeNone);
                 hidManager = NULL;
@@ -209,7 +196,7 @@ static void __XPC_Connection_Handler(xpc_connection_t connection) {
 
 void signalHandler(int signum) {
     syslog(LOG_NOTICE, "Received signal %d. Cleaning up...", signum);
-    close_all_seized();
+    close_all_locked();
     if (hidManager != NULL) {
         IOHIDManagerClose(hidManager, kIOHIDOptionsTypeNone);
         hidManager = NULL;

--- a/yubiswitch.helper/main.c
+++ b/yubiswitch.helper/main.c
@@ -32,7 +32,11 @@
 
 
 IOHIDManagerRef hidManager;
-IOHIDDeviceRef hidDevice;
+// Set of currently seized IOHIDDeviceRefs. Using a set (instead of a single
+// global) lets us seize and, crucially, release every matching key when several
+// Yubico devices are plugged in at once. kCFTypeSetCallBacks retains on add and
+// releases on remove, and dedups identical device refs.
+CFMutableSetRef seizedDevices;
 
 static void match_set(CFMutableDictionaryRef dict, CFStringRef key, int value) {
     CFNumberRef number = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &value);
@@ -40,16 +44,27 @@ static void match_set(CFMutableDictionaryRef dict, CFStringRef key, int value) {
     CFRelease(number);
 }
 
+static void close_device_apply(const void *value, void *context) {
+    IOHIDDeviceClose((IOHIDDeviceRef)value, kIOHIDOptionsTypeSeizeDevice);
+}
+
+// Release every seized device and empty the set.
+static void close_all_seized(void) {
+    if (seizedDevices != NULL) {
+        CFSetApplyFunction(seizedDevices, close_device_apply, NULL);
+        CFSetRemoveAllValues(seizedDevices);
+    }
+}
+
 static void handle_removal_callback(void *context, IOReturn result,
                                     void *sender, IOHIDDeviceRef device) {
-    if (hidDevice != NULL) {
+    // Only release the device that was actually unplugged. Leave the manager and
+    // any other seized devices in place so remaining keys stay seized and a
+    // re-plug of the same product still matches.
+    if (seizedDevices != NULL && CFSetContainsValue(seizedDevices, device)) {
         syslog(LOG_NOTICE, "device unplugged");
-        IOHIDDeviceClose(hidDevice, kIOHIDOptionsTypeSeizeDevice);
-        hidDevice = NULL;
-    }
-    if (hidManager != NULL) {
-        IOHIDManagerClose(hidManager, kIOHIDOptionsTypeNone);
-        hidManager = NULL;
+        IOHIDDeviceClose(device, kIOHIDOptionsTypeSeizeDevice);
+        CFSetRemoveValue(seizedDevices, device);
     }
 
     // lock screen
@@ -64,7 +79,11 @@ static void match_callback(void *context, IOReturn result, void *sender,
     IOReturn r = IOHIDDeviceOpen(device, kIOHIDOptionsTypeSeizeDevice);
     if (r == kIOReturnSuccess) {
         syslog(LOG_NOTICE, "Open'ed HID device");
-        hidDevice = device;
+        if (seizedDevices == NULL) {
+            seizedDevices = CFSetCreateMutable(kCFAllocatorDefault, 0,
+                                               &kCFTypeSetCallBacks);
+        }
+        CFSetAddValue(seizedDevices, device);
     } else {
         syslog(LOG_ALERT, "Failed to open HID device, error: %d", r);
     }
@@ -94,6 +113,32 @@ static CFDictionaryRef matching_dictionary_create(int vendorID, int productID,
     return match;
 }
 
+// Build the array of matching dictionaries handed to
+// IOHIDManagerSetDeviceMatchingMultiple (OR semantics across the array).
+// count == 0 means "no specific product IDs": match every product for the
+// vendor (a single vendor-only dictionary). Otherwise one dictionary per
+// product ID.
+static CFArrayRef matching_dictionaries_create(int vendorID, const int *productIDs,
+                                               size_t count, int usagePage,
+                                               int usage) {
+    CFMutableArrayRef matches =
+        CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+    if (count == 0) {
+        CFDictionaryRef match =
+            matching_dictionary_create(vendorID, 0, usagePage, usage);
+        CFArrayAppendValue(matches, match);
+        CFRelease(match);
+    } else {
+        for (size_t i = 0; i < count; i++) {
+            CFDictionaryRef match =
+                matching_dictionary_create(vendorID, productIDs[i], usagePage, usage);
+            CFArrayAppendValue(matches, match);
+            CFRelease(match);
+        }
+    }
+    return matches;
+}
+
 static void __XPC_Peer_Event_Handler(xpc_connection_t connection,
                                      xpc_object_t event) {
     xpc_type_t type = xpc_get_type(event);
@@ -102,18 +147,33 @@ static void __XPC_Peer_Event_Handler(xpc_connection_t connection,
         const char *description = xpc_dictionary_get_string(event, XPC_ERROR_KEY_DESCRIPTION);
         syslog(LOG_ALERT, "XPC error: %s", description);
     } else {
-        uint64_t idProduct = xpc_dictionary_get_int64(event, "idProduct");
         uint64_t idVendor = xpc_dictionary_get_int64(event, "idVendor");
         uint64_t action = xpc_dictionary_get_int64(event, "request");
-        syslog(LOG_NOTICE,
-               "Received message. idProduct: %llu, idVendor: %llu, action: %llu",
-               idProduct, idVendor, action);
-        if (action == 1) {
-            // enable
-            if (hidDevice != NULL) {
-                IOHIDDeviceClose(hidDevice, kIOHIDOptionsTypeSeizeDevice);
-                hidDevice = NULL;
+
+        // Collect the requested product IDs. Prefer the "idProducts" array; fall
+        // back to the legacy single "idProduct" key so an older GUI still works.
+        // An empty list means "match all products for the vendor".
+        int products[256];
+        size_t productCount = 0;
+        xpc_object_t idProducts = xpc_dictionary_get_value(event, "idProducts");
+        if (idProducts != NULL && xpc_get_type(idProducts) == XPC_TYPE_ARRAY) {
+            size_t n = xpc_array_get_count(idProducts);
+            for (size_t i = 0; i < n && productCount < 256; i++) {
+                products[productCount++] =
+                    (int)xpc_array_get_int64(idProducts, i);
             }
+        } else {
+            uint64_t idProduct = xpc_dictionary_get_int64(event, "idProduct");
+            if (idProduct != 0) {
+                products[productCount++] = (int)idProduct;
+            }
+        }
+        syslog(LOG_NOTICE,
+               "Received message. idVendor: %llu, product count: %zu, action: %llu",
+               idVendor, productCount, action);
+        if (action == 1) {
+            // enable: release every seized device and tear down the manager
+            close_all_seized();
             if (hidManager != NULL) {
                 IOHIDManagerClose(hidManager, kIOHIDOptionsTypeNone);
                 hidManager = NULL;
@@ -126,9 +186,10 @@ static void __XPC_Peer_Event_Handler(xpc_connection_t connection,
                 IOHIDManagerRegisterDeviceRemovalCallback(hidManager, handle_removal_callback, NULL);
                 IOHIDManagerScheduleWithRunLoop(hidManager, CFRunLoopGetMain(), kCFRunLoopCommonModes);
             }
-            CFDictionaryRef match = matching_dictionary_create((int)idVendor, (int)idProduct, 1, 6);
-            IOHIDManagerSetDeviceMatching(hidManager, match);
-            CFRelease(match);
+            CFArrayRef matches =
+                matching_dictionaries_create((int)idVendor, products, productCount, 1, 6);
+            IOHIDManagerSetDeviceMatchingMultiple(hidManager, matches);
+            CFRelease(matches);
         }
         xpc_connection_t remote = xpc_dictionary_get_remote_connection(event);
         xpc_object_t reply = xpc_dictionary_create_reply(event);
@@ -148,10 +209,7 @@ static void __XPC_Connection_Handler(xpc_connection_t connection) {
 
 void signalHandler(int signum) {
     syslog(LOG_NOTICE, "Received signal %d. Cleaning up...", signum);
-    if (hidDevice != NULL) {
-        IOHIDDeviceClose(hidDevice, kIOHIDOptionsTypeSeizeDevice);
-        hidDevice = NULL;
-    }
+    close_all_seized();
     if (hidManager != NULL) {
         IOHIDManagerClose(hidManager, kIOHIDOptionsTypeNone);
         hidManager = NULL;

--- a/yubiswitch.helper/yubiswitch-helper-Info.plist
+++ b/yubiswitch.helper/yubiswitch-helper-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>yubiswitch.helper</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>anchor apple generic and identifier &quot;com.pallotron.yubiswitch&quot; and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YX97W249KL)</string>

--- a/yubiswitch/DefaultPreferences.plist
+++ b/yubiswitch/DefaultPreferences.plist
@@ -18,7 +18,7 @@
 	<key>lockWhenUnplugged</key>
 	<false/>
 	<key>hotKeyProductID</key>
-	<string>0x0010</string>
+	<string></string>
 	<key>hotKeyVendorID</key>
 	<string>0x1050</string>
 	<key>switchOffDelay</key>

--- a/yubiswitch/PreferencesController.xib
+++ b/yubiswitch/PreferencesController.xib
@@ -90,7 +90,7 @@ Gw
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ngy-lT-sbn">
                         <rect key="frame" x="278" y="148" width="216" height="22"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="productID" placeholderString="" drawsBackground="YES" id="ZgX-Bs-98c">
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="productID" placeholderString="Blank = all Yubico; e.g. 0x0010,0x0407" drawsBackground="YES" id="ZgX-Bs-98c">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/yubiswitch/YubiKey.h
+++ b/yubiswitch/YubiKey.h
@@ -34,6 +34,9 @@
 
 @interface YubiKey : NSObject {
     BOOL suspend;
+    // HID manager used to detect unplug of a controlled key (lock-when-unplugged).
+    // Kept so it can be torn down and rebuilt when preferences change.
+    IOHIDManagerRef removalManager;
 }
 
 -(id)init;

--- a/yubiswitch/YubiKey.m
+++ b/yubiswitch/YubiKey.m
@@ -245,8 +245,6 @@
         xpc_array_set_int64(products, XPC_ARRAY_APPEND, [pid longLongValue]);
     }
     xpc_dictionary_set_value(message, "idProducts", products);
-    // Legacy single-value key, kept at 0 so an older helper stays functional.
-    xpc_dictionary_set_int64(message, "idProduct", 0);
     if ([action isEqualToString:@"enable"]) {
         xpc_dictionary_set_int64(message, "request", 1);
         suspend = FALSE;

--- a/yubiswitch/YubiKey.m
+++ b/yubiswitch/YubiKey.m
@@ -172,8 +172,34 @@
 
 - (void)notificationReloadHandler:(NSNotification *)notification {
     if ([[notification name] isEqualToString:@"changeDefaultsPrefs"]) {
+        // Rebuild the unplug matcher so vendor/product changes take effect
+        // without an app restart, then re-issue disable with the new IDs.
+        [self registerKeyRemoval];
         [self disable];
     }
+}
+
+// Parse the hotKeyProductID preference into a list of product IDs.
+// The field accepts a comma-separated list of hex IDs (e.g. "0x0010,0x0407").
+// An empty/blank string (or one with no valid tokens) yields an empty array,
+// which downstream means "match all products for the vendor".
+- (NSArray<NSNumber *> *)parseProductIDs:(NSString *)s {
+    NSMutableArray<NSNumber *> *result = [NSMutableArray array];
+    if (s == nil) {
+        return result;
+    }
+    for (NSString *token in [s componentsSeparatedByString:@","]) {
+        NSString *trimmed = [token stringByTrimmingCharactersInSet:
+                             [NSCharacterSet whitespaceCharacterSet]];
+        if ([trimmed length] == 0) {
+            continue;
+        }
+        unsigned int value = 0;
+        if ([[NSScanner scannerWithString:trimmed] scanHexInt:&value] && value != 0) {
+            [result addObject:@(value)];
+        }
+    }
+    return result;
 }
 
 - (BOOL)action:(NSString *)action {
@@ -207,15 +233,20 @@
         [[NSUserDefaults standardUserDefaults] stringForKey:@"hotKeyVendorID"];
     [[NSScanner scannerWithString:value] scanHexInt:&idVendor];
 
-    unsigned int idProduct = 0;
-    value =
-        [[NSUserDefaults standardUserDefaults] stringForKey:@"hotKeyProductID"];
-    [[NSScanner scannerWithString:value] scanHexInt:&idProduct];
+    NSArray<NSNumber *> *productIDs = [self parseProductIDs:
+        [[NSUserDefaults standardUserDefaults] stringForKey:@"hotKeyProductID"]];
 
     xpc_connection_resume(connection);
     xpc_object_t message = xpc_dictionary_create(NULL, NULL, 0);
     xpc_dictionary_set_int64(message, "idVendor", idVendor);
-    xpc_dictionary_set_int64(message, "idProduct", idProduct);
+    // Send the list of product IDs (empty = match all products for the vendor).
+    xpc_object_t products = xpc_array_create(NULL, 0);
+    for (NSNumber *pid in productIDs) {
+        xpc_array_set_int64(products, XPC_ARRAY_APPEND, [pid longLongValue]);
+    }
+    xpc_dictionary_set_value(message, "idProducts", products);
+    // Legacy single-value key, kept at 0 so an older helper stays functional.
+    xpc_dictionary_set_int64(message, "idProduct", 0);
     if ([action isEqualToString:@"enable"]) {
         xpc_dictionary_set_int64(message, "request", 1);
         suspend = FALSE;
@@ -266,33 +297,64 @@ static void match_set(CFMutableDictionaryRef dict, CFStringRef key, int value) {
     CFRelease(number);
 }
 
-- (void)registerKeyRemoval {
-
-    unsigned int idVendor = 0;
-    unsigned int idProduct = 0;
-
-    NSString *value = [[NSUserDefaults standardUserDefaults] stringForKey:@"hotKeyVendorID"];
-    [[NSScanner scannerWithString:value] scanHexInt:&idVendor];
-
-    value = [[NSUserDefaults standardUserDefaults] stringForKey:@"hotKeyProductID"];
-    [[NSScanner scannerWithString:value] scanHexInt:&idProduct];
-
-    IOHIDManagerRef hidManager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
-
+// Build a match dictionary for the OTP keyboard interface. A productID of 0
+// omits the product key, matching every product for the vendor.
+static CFDictionaryRef create_match_dict(int vendorID, int productID) {
     CFMutableDictionaryRef match = CFDictionaryCreateMutable(kCFAllocatorDefault,
                                                              0,
                                                              &kCFTypeDictionaryKeyCallBacks,
                                                              &kCFTypeDictionaryValueCallBacks);
-    match_set(match, CFSTR(kIOHIDVendorIDKey), idVendor);
-    match_set(match, CFSTR(kIOHIDProductIDKey), idProduct);
+    match_set(match, CFSTR(kIOHIDVendorIDKey), vendorID);
+    if (productID) {
+        match_set(match, CFSTR(kIOHIDProductIDKey), productID);
+    }
     match_set(match, CFSTR(kIOHIDDeviceUsagePageKey), 1);
     match_set(match, CFSTR(kIOHIDDeviceUsageKey), 6);
+    return match;
+}
 
-    IOHIDManagerScheduleWithRunLoop(hidManager, CFRunLoopGetMain(), kCFRunLoopCommonModes);
-    IOHIDManagerSetDeviceMatching(hidManager, match);
-    IOHIDManagerRegisterDeviceRemovalCallback(hidManager, handle_removal_callback, NULL);
+- (void)registerKeyRemoval {
 
-    CFRelease(match);
+    // Tear down any previously-created manager so preference changes don't stack
+    // duplicate removal callbacks or leak managers.
+    if (removalManager != NULL) {
+        IOHIDManagerUnscheduleFromRunLoop(removalManager, CFRunLoopGetMain(),
+                                          kCFRunLoopCommonModes);
+        IOHIDManagerClose(removalManager, kIOHIDOptionsTypeNone);
+        CFRelease(removalManager);
+        removalManager = NULL;
+    }
+
+    unsigned int idVendor = 0;
+    NSString *value = [[NSUserDefaults standardUserDefaults] stringForKey:@"hotKeyVendorID"];
+    [[NSScanner scannerWithString:value] scanHexInt:&idVendor];
+
+    NSArray<NSNumber *> *productIDs = [self parseProductIDs:
+        [[NSUserDefaults standardUserDefaults] stringForKey:@"hotKeyProductID"]];
+
+    removalManager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+
+    // OR-match one dictionary per product ID, or a single vendor-only dictionary
+    // when no specific product IDs are configured (match all Yubico devices).
+    CFMutableArrayRef matches =
+        CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+    if ([productIDs count] == 0) {
+        CFDictionaryRef match = create_match_dict((int)idVendor, 0);
+        CFArrayAppendValue(matches, match);
+        CFRelease(match);
+    } else {
+        for (NSNumber *pid in productIDs) {
+            CFDictionaryRef match = create_match_dict((int)idVendor, [pid intValue]);
+            CFArrayAppendValue(matches, match);
+            CFRelease(match);
+        }
+    }
+
+    IOHIDManagerScheduleWithRunLoop(removalManager, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+    IOHIDManagerSetDeviceMatchingMultiple(removalManager, matches);
+    IOHIDManagerRegisterDeviceRemovalCallback(removalManager, handle_removal_callback, NULL);
+
+    CFRelease(matches);
 }
 
 @end

--- a/yubiswitch/yubiswitch-Info.plist
+++ b/yubiswitch/yubiswitch-Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.18</string>
+	<string>0.19</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.18</string>
+	<string>0.19</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Automatically detect and switch all Yubico keys by default. If specified by the user, only lock specific product IDs.